### PR TITLE
Change order of ascended heros so the ascended version comes first

### DIFF
--- a/src/app/character-service/characters.json
+++ b/src/app/character-service/characters.json
@@ -236,20 +236,20 @@
 		"element": "Water"
 	},
 	{
-		"id": "Craig",
+		"id": "Craig_Ascended",
 		"aiType": "Melee",
 		"class": "Tank",
-		"isRare": true,
-		"imgName": "Craig.png",
+		"imgName": "Craig_Ascended.png",
 		"chainsFrom": "Downed",
 		"chainsTo": "Airborne",
 		"element": "Earth"
 	},
 	{
-		"id": "Craig_Ascended",
+		"id": "Craig",
 		"aiType": "Melee",
 		"class": "Tank",
-		"imgName": "Craig_Ascended.png",
+		"isRare": true,
+		"imgName": "Craig.png",
 		"chainsFrom": "Downed",
 		"chainsTo": "Airborne",
 		"element": "Earth"
@@ -301,20 +301,20 @@
 		"element": "Light"
 	},
 	{
-		"id": "Elvira",
+		"id": "Elvira_Ascended",
 		"aiType": "Melee",
 		"class": "Ranged",
-		"isRare": true,
-		"imgName": "Elvira.png",
+		"imgName": "Elvira_Ascended.png",
 		"chainsFrom": "Airborne",
 		"chainsTo": "Downed",
 		"element": "Fire"
 	},
 	{
-		"id": "Elvira_Ascended",
+		"id": "Elvira",
 		"aiType": "Melee",
 		"class": "Ranged",
-		"imgName": "Elvira_Ascended.png",
+		"isRare": true,
+		"imgName": "Elvira.png",
 		"chainsFrom": "Airborne",
 		"chainsTo": "Downed",
 		"element": "Fire"
@@ -376,20 +376,20 @@
 		"element": "Water"
 	},
 	{
-		"id": "Fei",
+		"id": "Fei_Ascended",
 		"aiType": "Melee",
 		"class": "Warrior",
-		"isRare": true,
-		"imgName": "Fei.png",
+		"imgName": "Fei_Ascended.png",
 		"chainsFrom": "Downed",
 		"chainsTo": "Airborne",
 		"element": "Light"
 	},
 	{
-		"id": "Fei_Ascended",
+		"id": "Fei",
 		"aiType": "Melee",
 		"class": "Warrior",
-		"imgName": "Fei_Ascended.png",
+		"isRare": true,
+		"imgName": "Fei.png",
 		"chainsFrom": "Downed",
 		"chainsTo": "Airborne",
 		"element": "Light"
@@ -506,21 +506,21 @@
 		"element": "Basic"
 	},
 	{
+		"id": "Karina_Ascended",
+		"aiType": "Ranged",
+		"class": "Support",
+		"imgName": "Karina_Ascended.png",
+		"chainsFrom": "All",
+		"chainsTo": "Injured",
+		"element": "Dark"
+	},
+	{
 		"id": "Karina",
 		"aiType": "Ranged",
 		"class": "Support",
 		"isRare": true,
 		"imgName": "Karina.png",
 		"chainsFrom": "Downed",
-		"chainsTo": "Injured",
-		"element": "Dark"
-	},
-	{
-		"id": "Karina_Ascended",
-		"aiType": "Ranged",
-		"class": "Support",
-		"imgName": "Karina_Ascended.png",
-		"chainsFrom": "All",
 		"chainsTo": "Injured",
 		"element": "Dark"
 	},
@@ -716,20 +716,20 @@
 		"element": "Earth"
 	},
 	{
-		"id": "Mei",
+		"id": "Mei_Ascended",
 		"aiType": "Melee",
 		"class": "Warrior",
-		"isRare": true,
-		"imgName": "Mei.png",
+		"imgName": "Mei_Ascended.png",
 		"chainsFrom": "Downed",
 		"chainsTo": "Airborne",
 		"element": "Light"
 	},
 	{
-		"id": "Mei_Ascended",
+		"id": "Mei",
 		"aiType": "Melee",
 		"class": "Warrior",
-		"imgName": "Mei_Ascended.png",
+		"isRare": true,
+		"imgName": "Mei.png",
 		"chainsFrom": "Downed",
 		"chainsTo": "Airborne",
 		"element": "Light"
@@ -847,15 +847,15 @@
 			"Echesaks model R"
 		]
 	},
-  {
-      "id": "Plague Doctor",
-      "aiType": "Melee",
-      "class": "Warrior",
-      "imgName": "PlagueDoctor.png",
-      "chainsFrom": "Downed",
-      "chainsTo": "Injured",
-      "element": "Dark"
-  },
+	{
+		"id": "Plague Doctor",
+		"aiType": "Melee",
+		"class": "Warrior",
+		"imgName": "PlagueDoctor.png",
+		"chainsFrom": "Downed",
+		"chainsTo": "Injured",
+		"element": "Dark"
+	},
 	{
 		"id": "Plitvice",
 		"aiType": "Melee",
@@ -1135,7 +1135,7 @@
 		"chainsTo": "Injured",
 		"element": "Dark"
 	},
-  {
+	{
 		"id": "Yuna",
 		"aiType": "Ranged",
 		"class": "Support",


### PR DESCRIPTION
When using the colo calc it's very convenient to just press Enter after searching a hero. I always use the ascended version of rare heroes, so it's annoying having to switch to trackpad to click the second hero to get the ascended version.